### PR TITLE
Solve typing error

### DIFF
--- a/src/BQ27427.cpp
+++ b/src/BQ27427.cpp
@@ -17,7 +17,7 @@ https://github.com/sparkfun/SparkFun_BQ274xx_Arduino_Library
  ************************** Initialization Functions *************************
  *****************************************************************************/
 // Initializes class variables
-BQ27427::BQ27427(uint16_t capacity, uint8_t deviceAddress, uint16_t designVoltage, uint16_t taperCurrent, uint16_t terminateVoltage, uint8_t chemId)
+BQ27427::BQ27427(uint16_t capacity, uint8_t deviceAddress, uint16_t designVoltage, uint16_t taperCurrent, uint16_t terminateVoltage, uint16_t chemId)
 {
 	_wire.addr = deviceAddress;
 	_wire.bus = &_bq27427;

--- a/src/BQ27427.h
+++ b/src/BQ27427.h
@@ -31,7 +31,7 @@ public:
 					uint16_t designVoltage = 4200, 
 					uint16_t taperCurrent = 20, 
 					uint16_t terminateVoltage = 3000,
-          uint8_t chemId = BQ27427_CHEM_ID_A); // Lithium Cobalt Oxide (LiCoO₂)
+          uint16_t chemId = BQ27427_CHEM_ID_A); // Lithium Cobalt Oxide (LiCoO₂)
 	
 	/**
 	    Initializes I2C and verifies communication with the BQ274xx.


### PR DESCRIPTION
Casting "chemId" to "uint8_t" will loose data. Specifically when passing BQ27427_CHEM_ID_A that has a decimal value of 12848, it will be converted to just 48. BQ27427_CHEM_ID_B is 4610 and BQ27427_CHEM_ID_C is 12610, so the error will happen to these as well.